### PR TITLE
chore: update to latest dependabot merge action

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -52,6 +52,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: fastify/github-action-merge-dependabot@v2.0.0
+      - uses: fastify/github-action-merge-dependabot@v2.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Because the old version points to a version of the backing Web application which is going to be decommissioned.